### PR TITLE
feat: account-based heats; unbound accounts from programs

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,4 @@
+export const config = {
+    svgLength: 1150,
+    svgHeight: 650,
+  };

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 <body>
     <div class="container">
         <h1>Solana Local Fee Market Heatmap</h1>
-        <svg id="visualization" width="800" height="600"></svg>
+        <svg id="visualization" width="1150" height="650"></svg>
         <pre id="block-info"></pre>
     </div>
     <script src="/app.js" type="module"></script>

--- a/public/utils.js
+++ b/public/utils.js
@@ -40,3 +40,12 @@ export function hideTooltip(tooltip) {
         .duration(500)
         .style("opacity", 0);
 }
+
+export function showTooltip(tooltip, event, content) {
+    tooltip.transition()
+        .duration(200)
+        .style("opacity", .9);
+    tooltip.html(content)
+        .style("left", (event.pageX) + "px")
+        .style("top", (event.pageY - 28) + "px");
+}

--- a/public/utils.js
+++ b/public/utils.js
@@ -13,22 +13,6 @@ export function scaleHashToNumber(hash, min, max) {
     return ((hashInt / 0xffffffff) * (max - min)) + min; //normalize and then scale
 }
 
-export function pruneStrayTooltips(svg, tooltip) {
-    const observer = new MutationObserver(mutations => {
-        for (const mutation of mutations) {
-            if (mutation.type === 'childList') {
-                const circleExists = svg.select("circle").node();
-                const lineExists = svg.select("line").node();
-                if (!circleExists && !lineExists) {
-                    tooltip.remove();
-                }
-            }
-        }
-    });
-
-    observer.observe(svg.node(), { childList: true });
-}
-
 export function createTooltip() {
     return d3.select("body").append("div")
         .attr("class", "tooltip")

--- a/public/visualization.js
+++ b/public/visualization.js
@@ -132,48 +132,7 @@ class AccountNodev2 {
     get alpha() {
         return 1 - this.fadedness;
     }
-
-/*
-    drawBackgroundShape(svg) {
-        const gradientId = `gradient-${Math.random().toString(36).substring(2)}`;
     
-        // Define a radial gradient
-        const radialGradient = svg.append("defs")
-            .append("radialGradient")
-            .attr("id", gradientId)
-            .attr("cx", "50%")
-            .attr("cy", "50%")
-            .attr("r", "50%")
-            .attr("fx", "50%")
-            .attr("fy", "50%");
-    
-        // Define the gradient stops
-        const opacity = this.opacityScale(this.computeUnits);
-        radialGradient.append("stop")
-            .attr("offset", "0%")
-            //.attr("stop-color", this.fill)
-            .attr("stop-color", "red")
-            .attr("stop-opacity", opacity);
-        radialGradient.append("stop")
-            .attr("offset", "25%")
-            .attr("stop-color", "red")
-            //.attr("stop-color", this.fill)
-            .attr("stop-opacity", opacity * 0.8); // Multiply opacity by a factor to create a steeper drop-off
-        radialGradient.append("stop")
-            .attr("offset", "100%")
-            .attr("stop-color", "red")
-            //.attr("stop-color", this.fill)
-            .attr("stop-opacity", "0");
-    
-        // Draw the background circle with the radial gradient
-        const size = 20; // Set a constant size for the circles
-        svg.insert("circle", ":first-child")
-            .attr("cx", this.position.x)
-            .attr("cy", this.position.y)
-            .attr("r", size)
-            .attr("fill", `url(#${gradientId})`);
-    }
-    */
     drawBackgroundShape(svg) {
         const gradientId = `gradient-${Math.random().toString(36).substring(2)}`;
         
@@ -327,7 +286,6 @@ let programState = {};
 let lineState  = [];
 const FADE_INCREMENT = 0.34;
 
-
 export async function draw(data) {
     const originalAddressLabelMap = new Map(Object.entries(data.addressToLabelMap));
     console.log(originalAddressLabelMap);
@@ -369,22 +327,6 @@ export async function draw(data) {
             lineState = lineState.filter(item => item !== line);
         }
     });
-
-    /*
-    Object.keys(accountState).forEach(address => {
-        const node = accountState[address];
-        if (node.isFadedOut()) {
-            delete accountState[address];
-        }
-    });
-
-    Object.keys(programState).forEach(address => {
-        const node = programState[address];
-        if (node.isFadedOut()) {
-            delete programState[address];
-        }
-    });
-    */
 
     // Add new nodes if it's not already in the state
     for (const account of accounts) {
@@ -430,9 +372,6 @@ export async function draw(data) {
         }
     });
 
-
-
-
     // clear the svg
     console.log("clearing");
     svg.selectAll("*").remove();
@@ -473,7 +412,6 @@ export async function draw(data) {
     for (let program in programState) {
         const node = programState[program];
         const { x, y } = node.position;
-        // node.drawBackgroundShape(svg);
         drawProgram(svg, x, y, 6, node.fill, node.tooltipContent, tooltip)
             .style("opacity", programState[program].alpha);
     }
@@ -482,17 +420,13 @@ export async function draw(data) {
     for (let address in accountState) {
         const node = accountState[address];
         const { x, y } = node.position;
-        //console.log(x,y);
-        // node.drawBackgroundShape(svg);
-
-        //draw account node
+        // draw each
         drawAccount(svg, x, y, 4, node.fill, node.tooltipContent, tooltip)
             .style("opacity", accountState[address].alpha);
         node.drawBackgroundShape(svg);
     }
 
-    //pruneStrayTooltips(svg, tooltip);
-    //d3.selectAll(".tooltip").remove();
+    //Remove all but the last tooltip
     d3.selectAll(".tooltip")
     .filter((d, i, nodes) => i < nodes.length - 1)
     .remove();

--- a/public/visualization.js
+++ b/public/visualization.js
@@ -1,15 +1,6 @@
 import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7/+esm";
 import { computeSha256, scaleHashToNumber, pruneStrayTooltips, 
-    createTooltip, hideTooltip } from "./utils.js";    
-
-function showTooltip(tooltip, event, content) {
-    tooltip.transition()
-        .duration(200)
-        .style("opacity", .9);
-    tooltip.html(content)
-        .style("left", (event.pageX) + "px")
-        .style("top", (event.pageY - 28) + "px");
-}
+    createTooltip, hideTooltip, showTooltip } from "./utils.js";    
 
 function createScales(programs) {
     const lightnessScale = d3.scaleLinear()
@@ -76,128 +67,6 @@ function drawLine(linesGroup, x1, y1, x2, y2, opacity) {
         .attr("stroke", "grey")
         .attr("stroke-width", 0.5)
         .style("opacity", opacity);
-}
-
-class ProgramNode {
-    constructor(program, hash, lightnessScale, hueScale, opacityScale, totalComputeUnits) {
-        this.computeUnits = program.computeUnits;
-        this.addressLabel = program.programLabel;
-        this.associatedAddresses = program.associatedAddresses.map(addr => new AssociatedAccount(addr));
-        this.hash = hash;
-        this.fadedness = 0;
-        this.lightnessScale = lightnessScale;
-        this.hueScale = hueScale;
-
-        this.hue = this.calculateHue(this.hash);
-        this.lightness = lightnessScale(this.computeUnits);
-
-        // Opacity scale
-        this.opacityScale = opacityScale;
-        this.totalComputeUnits = totalComputeUnits;
-
-    }
-
-    get position() {
-        const xOffset = 42;
-        const yOffset = 42;
-        return {
-            x: scaleHashToNumber(this.hash, xOffset, 800 - xOffset),
-            y: scaleHashToNumber(this.hash.slice(8), yOffset, 600 - yOffset)
-        };
-    }
-
-    get fill() {
-        return `hsla(${this.hue}, 100%, ${this.lightness}%, ${1 - this.fadedness})`;
-    }
-
-    get tooltipContent() {
-        const percentage = ((this.computeUnits / this.totalComputeUnits) * 100).toFixed(2);
-        return `${this.addressLabel}<br/>Compute Units: ${this.computeUnits} (${percentage}%)`;
-    }
-
-    calculateHue(hash) {
-        const mixedHashPart = hash.slice(4, 8) + hash.slice(16, 20);
-        return this.hueScale(parseInt(mixedHashPart, 16));
-    }
-
-    fade() {
-        this.fadedness += FADE_INCREMENT;
-        this.associatedAddresses.forEach(addr => addr.fade());
-    }
-
-    isFadedOut(maxFadedness) {
-        return this.fadedness >= maxFadedness;
-    }
-
-    resetFadedness(program) {
-        this.fadedness = 0;
-        this.associatedAddresses
-            .filter(addr => program.associatedAddresses.includes(addr.address))
-            .forEach(addr => addr.resetFadedness());
-    }
-
-    updateComputeUnits(newComputeUnits) {
-        this.computeUnits = newComputeUnits;
-    }
-
-    drawBackgroundShape(svg) {
-        const gradientId = `gradient-${Math.random().toString(36).substring(2)}`;
-    
-        // Define a radial gradient
-        const radialGradient = svg.append("defs")
-            .append("radialGradient")
-            .attr("id", gradientId)
-            .attr("cx", "50%")
-            .attr("cy", "50%")
-            .attr("r", "50%")
-            .attr("fx", "50%")
-            .attr("fy", "50%");
-    
-        // Define the gradient stops
-        const opacity = this.opacityScale(this.computeUnits);
-        radialGradient.append("stop")
-            .attr("offset", "0%")
-            .attr("stop-color", this.fill)
-            .attr("stop-opacity", opacity);
-        radialGradient.append("stop")
-            .attr("offset", "25%")
-            .attr("stop-color", this.fill)
-            .attr("stop-opacity", opacity * 0.8); // Multiply opacity by a factor to create a steeper drop-off
-        radialGradient.append("stop")
-            .attr("offset", "100%")
-            .attr("stop-color", this.fill)
-            .attr("stop-opacity", "0");
-    
-        // Draw the background circle with the radial gradient
-        const size = 200; // Set a constant size for the circles
-        svg.insert("circle", ":first-child")
-            .attr("cx", this.position.x)
-            .attr("cy", this.position.y)
-            .attr("r", size)
-            .attr("fill", `url(#${gradientId})`);
-    }
-    
-    
-
-}
-
-class AssociatedAccount {
-    constructor(address) {
-        this.address = address;
-        this.fadedness = 0;
-    }
-
-    fade() {
-        this.fadedness += FADE_INCREMENT;
-    }
-
-    resetFadedness() {
-        this.fadedness = 0;
-    }
-
-    get alpha() {
-        return 1 - this.fadedness;
-    }
 }
 
 class AccountNodev2 {
@@ -349,6 +218,22 @@ class ProgramNodev2 {
         return this.hueScale(parseInt(mixedHashPart, 16));
     }
 
+    get tooltipContent() {
+        return `${this.addressLabel}<br/>Compute Units: ${this.computeUnits}`;
+    }
+
+    fade() {
+        this.fadedness += FADE_INCREMENT;
+    }
+
+    resetFadedness() {
+        this.fadedness = 0;
+    }
+
+    isFadedOut(maxFadedness) {
+        return this.fadedness >= maxFadedness;
+    }
+
 }
 
 let accountState = {};
@@ -361,9 +246,6 @@ export async function draw(data) {
     console.log(originalAddressLabelMap);
     const svg = d3.select("#visualization");
 
-    // clear the svg
-    console.log("clearing");
-    svg.selectAll("*").remove();
 
     const accounts = data.informativeAccounts;
     const programCompute = data.programsComputeUnits;
@@ -382,12 +264,20 @@ export async function draw(data) {
 
     // Fade all nodes
     Object.values(accountState).forEach(node => node.fade());
+    Object.values(programState).forEach(node => node.fade());
 
     //Go through all nodes and if something has fadedness == maxFadedness, delete it
     Object.keys(accountState).forEach(address => {
         const node = accountState[address];
         if (node.isFadedOut(maxFadedness)) {
             delete accountState[address];
+        }
+    });
+
+    Object.keys(programState).forEach(address => {
+        const node = programState[address];
+        if (node.isFadedOut(maxFadedness)) {
+            delete programState[address];
         }
     });
 
@@ -415,7 +305,7 @@ export async function draw(data) {
                             break;
                         }
                     }
-                    programState[program] = new ProgramNodev2(hash, program, originalAddressLabelMap[program], [address], computeUnits, lightnessScale, hueScale);
+                    programState[program] = new ProgramNodev2(hash, program, originalAddressLabelMap.get(program), [address], computeUnits, lightnessScale, hueScale);
                 }
             }
         } else {
@@ -434,6 +324,11 @@ export async function draw(data) {
             delete programState[program];
         }
     });
+
+
+    // clear the svg
+    console.log("clearing");
+    svg.selectAll("*").remove();
 
     // Draw nodes
 
@@ -456,65 +351,7 @@ export async function draw(data) {
         //draw account node
         drawAccount(svg, x, y, 4, node.fill, node.tooltipContent, tooltip)
             .style("opacity", accountState[address].alpha);
-
-
     }
+
     pruneStrayTooltips(svg, tooltip);
-
-
-/*
-    const totalComputeUnits = data.computeUnitsMeta;
-    // Add new nodes if it's not already in the state
-    for (const program of programs) {
-        const address = program.programAddress;
-        const hash = await computeSha256(address);
-
-        if (address in state) {
-            // Reset fadedness if node already exists in state
-            state[address].resetFadedness(program);
-            // Update compute units
-            state[address].updateComputeUnits(program.computeUnits);
-        } else {
-            // Add new node to state
-            state[address] = new ProgramNode(program, hash, lightnessScale, hueScale, opacityScale, totalComputeUnits);
-        }
-    }
-
-    // Draw nodes
-    for (let address in state) {
-        const node = state[address];
-        const { x, y } = node.position;
-
-        node.drawBackgroundShape(svg);
-
-        for (const associatedAccount of node.associatedAddresses) {
-            if (associatedAccount.fadedness < maxFadedness) {
-                await drawAssociatedAddresses(linesGroup, x,y, associatedAccount, svg, tooltip, zoneRadius);
-            }
-        }
-
-        // Draw program circle
-       drawProgram(svg, x, y, 6, node.fill, node.tooltipContent, tooltip);
-
-    }
-    pruneStrayTooltips(svg, tooltip);
-
-*/
-
-
-}
-
-async function drawAssociatedAddresses(linesGroup, programCx, programCy, associatedAccount, svg, tooltip, zoneRadius) {
-    // const programCx = +programCircle.attr("cx"); //coerce to number
-    // const programCy = +programCircle.attr("cy");
-    const hash = await computeSha256(associatedAccount.address);
-    const angle = scaleHashToNumber(hash, 0, 2 * Math.PI);
-    const radius = scaleHashToNumber(hash.slice(8), 10, zoneRadius);
-
-    const cx = programCx + radius * Math.cos(angle);
-    const cy = programCy + radius * Math.sin(angle);
-
-    drawLine(linesGroup, programCx, programCy, cx, cy, associatedAccount.alpha);
-    drawAccount(svg, cx, cy, 2, "#999999", associatedAccount.address, tooltip)
-        .style("opacity", associatedAccount.alpha);
 }

--- a/public/visualization.js
+++ b/public/visualization.js
@@ -59,13 +59,14 @@ function drawAccount(svg, cx, cy, radius, fill, content, tooltip) {
 }
 
 function drawLine(linesGroup, x1, y1, x2, y2, opacity) {
+    console.log(`Drawing line from (${x1}, ${y1}) to (${x2}, ${y2}) with opacity ${opacity}`);
     linesGroup.append("line")
         .attr("x1", x1)
         .attr("y1", y1)
         .attr("x2", x2)
         .attr("y2", y2)
-        .attr("stroke", "grey")
-        .attr("stroke-width", 0.5)
+        .attr("stroke", "red")
+        .attr("stroke-width", 2)
         .style("opacity", opacity);
 }
 
@@ -252,7 +253,7 @@ export async function draw(data) {
     //const { lightnessScale, hueScale } = createScales(programs);
     const { lightnessScale, hueScale } = createScales(accounts);
     const tooltip = createTooltip();
-    const linesGroup = svg.append("g");
+    
     const maxFadedness = 3;
 
 
@@ -326,9 +327,22 @@ export async function draw(data) {
     });
 
 
+
+
     // clear the svg
     console.log("clearing");
     svg.selectAll("*").remove();
+    let lines = svg.append("g").attr("id", "linesGroup"); // add id for clarity
+
+    //Draw lines
+    for (let program in programState) {
+        const node = programState[program];
+        const { x: x1, y: y1 } = node.position;
+        for (let account of node.associatedAccounts) {
+            const { x: x2, y: y2 } = accountState[account].position;
+            drawLine(lines, x1, y1, x2, y2, node.fill, accountState[account].fill, node.alpha, accountState[account].alpha);
+        }
+    }
 
     // Draw nodes
 

--- a/public/visualization.js
+++ b/public/visualization.js
@@ -23,7 +23,7 @@ function createScales(programs) {
     return { lightnessScale, hueScale };
 }
 
-function drawCircle(svg, cx, cy, radius, fill, content, tooltip) {
+function drawProgram(svg, cx, cy, radius, fill, content, tooltip) {
     const circle = svg.append("circle")
         .attr("cx", cx)
         .attr("cy", cy)
@@ -31,6 +31,28 @@ function drawCircle(svg, cx, cy, radius, fill, content, tooltip) {
         .attr("fill", fill)
         .on("mouseover", event => showTooltip(tooltip, event, content))
         .on("mouseout", () => hideTooltip(tooltip));
+
+    // Pulse animation to indicate the circle was in the most recent block
+    circle.transition()
+        .duration(600)
+        .ease(d3.easeElastic)
+        .attr("r", radius * 1.3)
+        .transition()
+        .duration(600)
+        .ease(d3.easeElastic)
+        .attr("r", radius);
+
+    return circle;
+}
+
+function drawAccount(svg, cx, cy, radius, fill, content, tooltip) {
+    const circle = svg.append("circle")
+    .attr("cx", cx)
+    .attr("cy", cy)
+    .attr("r", radius)
+    .attr("fill", fill)
+    .on("mouseover", event => showTooltip(tooltip, event, content))
+    .on("mouseout", () => hideTooltip(tooltip));
 
     // Pulse animation to indicate the circle was in the most recent block
     circle.transition()
@@ -244,7 +266,7 @@ export async function draw(data) {
         }
 
         // Draw program circle
-       drawCircle(svg, x, y, 6, node.fill, node.tooltipContent, tooltip);
+       drawProgram(svg, x, y, 6, node.fill, node.tooltipContent, tooltip);
 
     }
     pruneStrayTooltips(svg, tooltip);
@@ -261,6 +283,6 @@ async function drawAssociatedAddresses(linesGroup, programCx, programCy, associa
     const cy = programCy + radius * Math.sin(angle);
 
     drawLine(linesGroup, programCx, programCy, cx, cy, associatedAccount.alpha);
-    drawCircle(svg, cx, cy, 2, "#999999", associatedAccount.address, tooltip)
+    drawAccount(svg, cx, cy, 2, "#999999", associatedAccount.address, tooltip)
         .style("opacity", associatedAccount.alpha);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+export const config = {
+    topAccountsCount: 100,
+    svgLength: 1150,
+    svgHeight: 650,
+  };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const app = express();
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 const PORT = process.env.PORT || 3000;
+import { config } from './config';
 app.use(express.static('public'));
 
 //ws to solana
@@ -203,6 +204,13 @@ async function processBlock(block: BlockResponse) {
 
             informativeAccounts.push(currentInformativeAccount);
 
+        }
+
+        if (config) {
+            // Sort informativeAccounts array based on computeUnits in descending order
+            informativeAccounts.sort((a, b) => b.computeUnits - a.computeUnits);
+            // Keep only the top compute unit accounts based on the configuration
+            informativeAccounts = informativeAccounts.slice(0, config.topAccountsCount);
         }
 
         let addressToLabelMap : Map<string, string> = new Map<string, string>();


### PR DESCRIPTION
Instead of plotting accounts around the vicinity of programs, make them always appear in the same coordinate regardless of the programs they interact with.

Account heats are Red if they reach the maximum CU of 12m, intermediate CUs are Pink, etc.

Add config options to change the size of the SVG and limit the number of accounts processed and drawn.